### PR TITLE
Fixed typo in utils.py. 

### DIFF
--- a/pyaadhaar/utils.py
+++ b/pyaadhaar/utils.py
@@ -45,7 +45,7 @@ def AadhaarQrAuto(data):
     if isSecureQr(data):
         return pyaadhaar.decode.AdhaarSecureQr(int(data))
     else:
-        return pyaadhaar.decode.AdhaarOldQr(data)
+        return pyaadhaar.decode.AadhaarOldQr(data)
 
 
 def Qr_img_to_text(file):


### PR DESCRIPTION
 Changed line 48 in utils.py
 return pyaadhaar.decode.AdhaarOldQr(data) 
 to 
 return pyaadhaar.decode.AadhaarOldQr(data)
 
 This was giving me errors. That's why.